### PR TITLE
[OSB-1] Change to avoid shutdown() error due to time out

### DIFF
--- a/osbrain/proxy.py
+++ b/osbrain/proxy.py
@@ -423,17 +423,23 @@ class NSProxy(Pyro4.core.Proxy):
             )
         )
 
-    def shutdown(self, timeout=10.0):
-        """
-        Shutdown the name server. All agents will be shutdown as well.
+    def shutdown(self, timeout=10.):
+       """
+       Shutdown the name server. All agents will be shutdown as well.
 
-        Parameters
-        ----------
-        timeout : float, default is 10.
-            Timeout, in seconds, to wait for the agents to shutdown.
-        """
-        self.shutdown_agents(timeout)
-        try:
-            super()._pyroInvoke('daemon_shutdown', (), {}, flags=0)
-        except ConnectionClosedError:
-            pass
+
+       Parameters
+       ----------
+       timeout : float, default is 10.
+           Timeout, in seconds, to wait for the agents to shutdown.
+       """
+       try:
+           self.shutdown_agents(timeout)
+       except TimeoutError as e:
+           raise
+       finally:
+           try:
+               super()._pyroInvoke('daemon_shutdown', (), {}, flags=0)
+           except ConnectionClosedError:
+               pass
+


### PR DESCRIPTION
In the`playground`repo, at `playground/osbrain/8_pull_bind_parallel` example, we can have an indefinite amount of clients PUSH connecting to the single PULL binding server (fair queuing in action).

It could happen that during the exchange of messages between agents running on each side of the wire, one client is terminated or the server looses connection with a client.

In such a case, if we try later to `ns.shutdown()`  the name server, the server will try to communicate with inaccessible client and a `Pyro4.TimeoutError` will be raised.

In the original `osbrain` implementation, although the `ns` is able to terminate all other agents asynchronously before closing, it gets stuck and never times out. 

With our change, the `try-catch` block now includes `shutdown_agents(timeout)` and the `finally` clause ensures the nameserver (`d_pyroInvoke('daemon_shutdown')` is shutdown gracefully